### PR TITLE
mod use of privatekey

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,7 +8,10 @@ const config: HardhatUserConfig = {
   networks: {
     testnet_aurora: {
       url: "https://testnet.aurora.dev",
-      // accounts: [process.env.AURORA_PRIVATE_KEY!],
+      accounts:
+        process.env.AURORA_PRIVATE_KEY !== undefined
+          ? [process.env.AURORA_PRIVATE_KEY]
+          : [],
     },
   },
 };


### PR DESCRIPTION
hardhat.config.ts内の環境変数`AURORA_PRIVATE_KEY`の使用方法について変更しました。

**修正前**

.envファイルの無い環境でテストを行いたい時, `AURORA_PRIVATE_KEY`がundefinedとなる.  
-> テストで`AURORA_PRIVATE_KEY`を使用する訳ではないが, ファイル内では`AURORA_PRIVATE_KEY!`とアサーションをつけているためfailする.   
-> 一時的な対応としてコメントアウトしているが, このままだとデプロイができない.  

**修正後**

`AURORA_PRIVATE_KEY`が存在する場合は使用し, undefinedの場合は使用しないようにしました.  
テストをする上では`AURORA_PRIVATE_KEY`が必要ないので, .envファイルのない環境でも実行可能.

もしマージ可能でしたらマージして頂き, コンテンツの方も修正して頂ければと思います。